### PR TITLE
필터 에러코드 변경,  권한검증 globalconst 설정

### DIFF
--- a/src/main/java/com/spartaordersystem/domains/category/service/CategoryService.java
+++ b/src/main/java/com/spartaordersystem/domains/category/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.spartaordersystem.domains.category.controller.dto.CategoryDto;
 import com.spartaordersystem.domains.category.entity.Category;
 import com.spartaordersystem.domains.category.repository.CategoryRepository;
 import com.spartaordersystem.domains.user.entity.User;
+import com.spartaordersystem.global.common.GlobalConst;
 import com.spartaordersystem.global.exception.CustomException;
 import com.spartaordersystem.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -70,7 +71,7 @@ public class CategoryService {
     }
 
     private void checkUserRole(String userRole) {
-        if (!(userRole.equals("ROLE_MANEGER") || userRole.equals("ROLE_ADMIN"))) {
+        if (!(userRole.equals(GlobalConst.ROLE_MANAGER) || userRole.equals(GlobalConst.ROLE_ADMIN))) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
     }

--- a/src/main/java/com/spartaordersystem/domains/category/service/StoreCategoryService.java
+++ b/src/main/java/com/spartaordersystem/domains/category/service/StoreCategoryService.java
@@ -5,6 +5,7 @@ import com.spartaordersystem.domains.category.repository.CategoryRepository;
 import com.spartaordersystem.domains.store.entity.Store;
 import com.spartaordersystem.domains.store.repository.StoreRepository;
 import com.spartaordersystem.domains.user.entity.User;
+import com.spartaordersystem.global.common.GlobalConst;
 import com.spartaordersystem.global.exception.CustomException;
 import com.spartaordersystem.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -45,7 +46,7 @@ public class StoreCategoryService {
     }
 
     private void checkUserRole(String userRole) {
-        if (!(userRole.equals("ROLE_OWNER") || userRole.equals("ROLE_MANEGER") || userRole.equals("ROLE_ADMIN"))) {
+        if (!(userRole.equals(GlobalConst.ROLE_OWNER) || userRole.equals(GlobalConst.ROLE_MANAGER) || userRole.equals(GlobalConst.ROLE_ADMIN))) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
     }
@@ -56,10 +57,10 @@ public class StoreCategoryService {
     }
 
     private void checkUserRole(String userRole, User user, Store store) {
-        if (userRole.equals("ROLE_OWNER")) {
+        if (userRole.equals(GlobalConst.ROLE_OWNER)) {
             checkUserIsStoreOwner(user, store);
         }
-        else if (!(userRole.equals("ROLE_MANAGER") || userRole.equals("ROLE_ADMIN"))) {
+        else if (!(userRole.equals(GlobalConst.ROLE_MANAGER) || userRole.equals(GlobalConst.ROLE_ADMIN))) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
     }

--- a/src/main/java/com/spartaordersystem/domains/store/service/StoreService.java
+++ b/src/main/java/com/spartaordersystem/domains/store/service/StoreService.java
@@ -9,6 +9,7 @@ import com.spartaordersystem.domains.store.enums.StoreStatus;
 import com.spartaordersystem.domains.store.repository.StoreRepository;
 import com.spartaordersystem.domains.user.entity.User;
 import com.spartaordersystem.domains.user.repository.UserRepository;
+import com.spartaordersystem.global.common.GlobalConst;
 import com.spartaordersystem.global.exception.CustomException;
 import com.spartaordersystem.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -119,17 +120,17 @@ public class StoreService {
 
     // 손님이 아니며, 가게주인인지 검증이 필요한 경우
     private void checkUserRole(String userRole, User user, Store store) {
-        if (userRole.equals("ROLE_OWNER")) {
+        if (userRole.equals(GlobalConst.ROLE_OWNER)) {
             checkUserIsStoreOwner(user, store);
         }
-        else if (!(userRole.equals("ROLE_MANAGER") || userRole.equals("ROLE_ADMIN"))) {
+        else if (!(userRole.equals(GlobalConst.ROLE_MANAGER) || userRole.equals(GlobalConst.ROLE_ADMIN))) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
     }
 
     // 손님만 아니면 될 경우
     private void checkUserRole(String userRole) {
-        if (!(userRole.equals("ROLE_OWNER") || userRole.equals("ROLE_MANAGER") || userRole.equals("ROLE_ADMIN"))) {
+        if (!(userRole.equals(GlobalConst.ROLE_OWNER) || userRole.equals(GlobalConst.ROLE_MANAGER) || userRole.equals(GlobalConst.ROLE_ADMIN))) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
     }

--- a/src/main/java/com/spartaordersystem/domains/storeMenu/service/MenuService.java
+++ b/src/main/java/com/spartaordersystem/domains/storeMenu/service/MenuService.java
@@ -1,19 +1,19 @@
 package com.spartaordersystem.domains.storeMenu.service;
 
+import com.spartaordersystem.domains.store.entity.Store;
+import com.spartaordersystem.domains.store.repository.StoreRepository;
 import com.spartaordersystem.domains.storeMenu.controller.dto.CreateMenuDto;
 import com.spartaordersystem.domains.storeMenu.controller.dto.UpdateMenuDto;
 import com.spartaordersystem.domains.storeMenu.entity.StoreMenu;
 import com.spartaordersystem.domains.storeMenu.repository.MenuRepository;
-import com.spartaordersystem.domains.store.entity.Store;
-import com.spartaordersystem.domains.store.repository.StoreRepository;
 import com.spartaordersystem.domains.user.entity.User;
+import com.spartaordersystem.global.common.GlobalConst;
 import com.spartaordersystem.global.exception.CustomException;
 import com.spartaordersystem.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.awt.*;
 import java.util.UUID;
 
 @Service
@@ -71,10 +71,10 @@ public class MenuService {
 
     // 손님이 아니며, 가게주인인지 검증이 필요한 경우
     private void checkUserRole(String userRole, User user, Store store) {
-        if (userRole.equals("ROLE_OWNER")) {
+        if (userRole.equals(GlobalConst.ROLE_OWNER)) {
             checkUserIsStoreOwner(user, store);
         }
-        else if (!(userRole.equals("ROLE_MANAGER") || userRole.equals("ROLE_ADMIN"))) {
+        else if (!(userRole.equals(GlobalConst.ROLE_MANAGER) || userRole.equals(GlobalConst.ROLE_ADMIN))) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
     }

--- a/src/main/java/com/spartaordersystem/global/common/GlobalConst.java
+++ b/src/main/java/com/spartaordersystem/global/common/GlobalConst.java
@@ -7,6 +7,6 @@ public final class GlobalConst {
     public static final String ROLE_USER = "ROLE_USER";
     public static final String ROLE_OWNER = "ROLE_OWNER";
     public static final String ROLE_MANAGER = "ROLE_MANAGER";
-    public static final String ROLE_MASTER = "ROLE_MASTER";
+    public static final String ROLE_ADMIN = "ROLE_ADMIN";
 
 }

--- a/src/main/java/com/spartaordersystem/global/security/user/UserDetailsServiceImpl.java
+++ b/src/main/java/com/spartaordersystem/global/security/user/UserDetailsServiceImpl.java
@@ -2,6 +2,8 @@ package com.spartaordersystem.global.security.user;
 
 import com.spartaordersystem.domains.user.entity.User;
 import com.spartaordersystem.domains.user.repository.UserRepository;
+import com.spartaordersystem.global.exception.CustomException;
+import com.spartaordersystem.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -16,7 +18,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         return new UserDetailsImpl(user);
     }


### PR DESCRIPTION
**필터에서 usernameNotFound 에러를  글로벌에러코드  USER_NOT_FOUND로 변경**

**권한검증에서 "ROLE_OWNER" 등 직접 상수로 입력하던 부분을 Global Const를 적용하여 일관성있게 관리**