### PR TITLE
[feat]  메뉴 단일 조회 구현 #26

### DIFF
--- a/src/main/java/com/spartaordersystem/domains/storeMenu/controller/MenuController.java
+++ b/src/main/java/com/spartaordersystem/domains/storeMenu/controller/MenuController.java
@@ -1,15 +1,18 @@
 package com.spartaordersystem.domains.storeMenu.controller;
 
 import com.spartaordersystem.domains.storeMenu.controller.dto.CreateMenuDto;
+import com.spartaordersystem.domains.storeMenu.controller.dto.GetMenuDto;
 import com.spartaordersystem.domains.storeMenu.controller.dto.UpdateMenuDto;
 import com.spartaordersystem.domains.storeMenu.service.MenuService;
 import com.spartaordersystem.domains.user.entity.User;
 import com.spartaordersystem.global.response.BaseResponse;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -67,6 +70,16 @@ public class MenuController {
     ) {
         menuService.updateMenuStatus(user, storeId, menuId);
         BaseResponse response = BaseResponse.toSuccessResponse("메뉴 상태가 변경되었습니다.");
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{storeId}/menus/{menuId}")
+    public ResponseEntity<BaseResponse> getMenuInfo(
+            @PathVariable UUID storeId,
+            @PathVariable UUID menuId
+    ) {
+        GetMenuDto.ResponseDto responseDto = menuService.getMenuInfo(storeId, menuId);
+        BaseResponse response = BaseResponse.toSuccessResponse("메뉴 정보 조회 성공", responseDto);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/spartaordersystem/domains/storeMenu/controller/dto/GetMenuDto.java
+++ b/src/main/java/com/spartaordersystem/domains/storeMenu/controller/dto/GetMenuDto.java
@@ -1,0 +1,22 @@
+package com.spartaordersystem.domains.storeMenu.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+public class GetMenuDto {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class ResponseDto {
+        private UUID id;
+        private String title;
+        private String description;
+        private long price;
+    }
+}

--- a/src/main/java/com/spartaordersystem/domains/storeMenu/service/MenuService.java
+++ b/src/main/java/com/spartaordersystem/domains/storeMenu/service/MenuService.java
@@ -3,6 +3,7 @@ package com.spartaordersystem.domains.storeMenu.service;
 import com.spartaordersystem.domains.store.entity.Store;
 import com.spartaordersystem.domains.store.repository.StoreRepository;
 import com.spartaordersystem.domains.storeMenu.controller.dto.CreateMenuDto;
+import com.spartaordersystem.domains.storeMenu.controller.dto.GetMenuDto;
 import com.spartaordersystem.domains.storeMenu.controller.dto.UpdateMenuDto;
 import com.spartaordersystem.domains.storeMenu.entity.StoreMenu;
 import com.spartaordersystem.domains.storeMenu.enums.MenuStatus;
@@ -87,6 +88,23 @@ public class MenuService {
         }
 
         menuRepository.save(menu);
+    }
+
+    @Transactional(readOnly = true)
+    public GetMenuDto.ResponseDto getMenuInfo(UUID storeId, UUID menuId) {
+        Store store = getStore(storeId);
+        StoreMenu menu = getMenu(menuId);
+
+        if (menu.getMenuStatus() == MenuStatus.SOLD_OUT || menu.isDeleted()) {
+            throw new CustomException(ErrorCode.MENU_NOT_FOUND);
+        }
+
+        return GetMenuDto.ResponseDto.builder()
+                .id(menu.getId())
+                .title(menu.getTitle())
+                .description(menu.getDescription())
+                .price(menu.getPrice())
+                .build();
     }
 
     private void checkUserIsStoreOwner(User user, Store store) {


### PR DESCRIPTION
## 요약

#26 

메뉴 단일 조회 구현
품절 처리 및 삭제 처리된 메뉴는 조회가 불가능하도록 검증하여 구현

## 진행

- [x] 품절인지 검증하는 로직 구현
- [x] 삭제되었는지 검증하는 로직 구현
- [x] 로직 구현

