### PR TITLE
[feat]  ai 연결 클라이언트 구현 #38

### DIFF
--- a/src/main/java/com/spartaordersystem/domains/ai/client/GeminiApiClient.java
+++ b/src/main/java/com/spartaordersystem/domains/ai/client/GeminiApiClient.java
@@ -1,0 +1,37 @@
+package com.spartaordersystem.domains.ai.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+
+@Component
+public class GeminiApiClient {
+
+    @Value("${gemini.api.key}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent";
+
+    public String createDescription(String title, long price, String details) {
+        String prompt = String.format("제목: %s, 가격: %d. %s. 답변은 최대한 간결하게 50자 이내로 해줘", title, price, details);
+
+        String requestBody = String.format(
+                "{\"prompt\": \"%s\", \"maxTokens\":50, \"temperature\": 0.8}", prompt
+        );
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.set("Content-Type", "application/json");
+        httpHeaders.set("Authorization", "Bearer" + apiKey);
+
+        HttpEntity<String> request = new HttpEntity<>(requestBody, httpHeaders);
+
+        ResponseEntity<String> response = restTemplate.exchange(GEMINI_API_URL, HttpMethod.POST, request, String.class);
+        return response.getBody();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,7 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: create-drop
+
+gemini:
+  api:
+    key: ${GEMINI_API_KEY}


### PR DESCRIPTION
## 요약

#38 

ai 연결

gemini api에 post요청을 보내 메뉴 설명을 생성
메뉴 이름, 가격, 세부 섦여을 바탕으로 프롬프트를 생성
생성한 답변을 json형식의 요청 본문에 담아 토큰으로 인증된 http요청을 보내며
api응답을 리턴