### PR TITLE
[feat]  ai 상품 설명 생성 및 menu 수정 #39 #40

### DIFF
--- a/src/main/java/com/spartaordersystem/domains/ai/client/GeminiApiClient.java
+++ b/src/main/java/com/spartaordersystem/domains/ai/client/GeminiApiClient.java
@@ -8,7 +8,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-
+/**
+ *  글로벌로 옮기고
+ *  인터페이스로 변경
+ *  ai 패키지에서는
+ *  impl을 만들어서 상속받게
+ *  하는게 좋다
+ *  리팩토링
+ */
 @Component
 public class GeminiApiClient {
 

--- a/src/main/java/com/spartaordersystem/domains/ai/controller/PromptController.java
+++ b/src/main/java/com/spartaordersystem/domains/ai/controller/PromptController.java
@@ -1,0 +1,46 @@
+package com.spartaordersystem.domains.ai.controller;
+
+import com.spartaordersystem.domains.ai.controller.dto.GetPromptDto;
+import com.spartaordersystem.domains.ai.controller.dto.PromptDto;
+import com.spartaordersystem.domains.ai.service.PromptService;
+import com.spartaordersystem.domains.store.entity.Store;
+import com.spartaordersystem.domains.storeMenu.entity.StoreMenu;
+import com.spartaordersystem.domains.user.entity.User;
+import com.spartaordersystem.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/ai")
+public class PromptController {
+
+    private final PromptService promptService;
+
+    @PostMapping("/stores/{storeId}/menus/{menuId}")
+    public ResponseEntity<BaseResponse> updateDescription(
+            @AuthenticationPrincipal User user,
+            @PathVariable UUID storeId,
+            @PathVariable UUID menuId,
+            @RequestBody PromptDto.RequestDto requestDto
+    ) {
+        PromptDto.ResponseDto responseDto = promptService.updateDescription(user, storeId, menuId, requestDto);
+        BaseResponse response = BaseResponse.toSuccessResponse("메뉴 설명에 대한 답변 생성에 성공하였습니다.", responseDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+
+}

--- a/src/main/java/com/spartaordersystem/domains/ai/controller/dto/PromptDto.java
+++ b/src/main/java/com/spartaordersystem/domains/ai/controller/dto/PromptDto.java
@@ -1,0 +1,28 @@
+package com.spartaordersystem.domains.ai.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+public class PromptDto {
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class RequestDto {
+        private String details;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class ResponseDto {
+        private UUID menuId;
+        private String description;
+    }
+
+}

--- a/src/main/java/com/spartaordersystem/domains/ai/entity/Prompt.java
+++ b/src/main/java/com/spartaordersystem/domains/ai/entity/Prompt.java
@@ -1,0 +1,53 @@
+package com.spartaordersystem.domains.ai.entity;
+
+import com.spartaordersystem.domains.storeMenu.entity.StoreMenu;
+import com.spartaordersystem.global.common.BaseAudit;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "p_prompt")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Prompt extends BaseAudit {
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @UuidGenerator
+    @JdbcTypeCode(SqlTypes.CHAR)
+    @Column(nullable = false, length = 36, unique = true) // UUID 값이 36자의 문자열로 저장됨
+    private UUID id;
+
+    @Column(nullable = false)
+    private String promptContent;
+
+    @Column(nullable = false)
+    private String answer;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_menu_id", nullable = false)
+    private StoreMenu storeMenu;
+
+    @Builder
+    public Prompt(String promptContent, String answer, StoreMenu storeMenu) {
+        this.promptContent = promptContent;
+        this.answer = answer;
+        this.storeMenu = storeMenu;
+    }
+}

--- a/src/main/java/com/spartaordersystem/domains/ai/repository/PromptRepository.java
+++ b/src/main/java/com/spartaordersystem/domains/ai/repository/PromptRepository.java
@@ -1,0 +1,11 @@
+package com.spartaordersystem.domains.ai.repository;
+
+import com.spartaordersystem.domains.ai.entity.Prompt;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface PromptRepository extends JpaRepository<Prompt, UUID> {
+}

--- a/src/main/java/com/spartaordersystem/domains/ai/service/PromptService.java
+++ b/src/main/java/com/spartaordersystem/domains/ai/service/PromptService.java
@@ -1,0 +1,110 @@
+package com.spartaordersystem.domains.ai.service;
+
+import com.spartaordersystem.domains.ai.client.GeminiApiClient;
+import com.spartaordersystem.domains.ai.controller.dto.GetPromptDto;
+import com.spartaordersystem.domains.ai.controller.dto.PromptDto;
+import com.spartaordersystem.domains.ai.entity.Prompt;
+import com.spartaordersystem.domains.ai.repository.PromptRepository;
+import com.spartaordersystem.domains.store.entity.Store;
+import com.spartaordersystem.domains.store.repository.StoreRepository;
+import com.spartaordersystem.domains.storeMenu.controller.dto.CreateMenuDto;
+import com.spartaordersystem.domains.storeMenu.entity.StoreMenu;
+import com.spartaordersystem.domains.storeMenu.repository.MenuRepository;
+import com.spartaordersystem.domains.user.entity.User;
+import com.spartaordersystem.global.common.GlobalConst;
+import com.spartaordersystem.global.exception.CustomException;
+import com.spartaordersystem.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.security.core.parameters.P;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PromptService {
+
+    private final GeminiApiClient geminiApiClient;
+    private final PromptRepository promptRepository;
+    private final MenuRepository menuRepository;
+    private final StoreRepository storeRepository;
+
+
+    // 기존에 존재하는 메뉴에 대한 설명 생성
+    @Transactional
+    public PromptDto.ResponseDto updateDescription(User user, UUID storeId, UUID menuId, PromptDto.RequestDto requestDto) {
+        StoreMenu menu = getMenu(menuId);
+        Store store = getStore(storeId);
+        checkUserRole(user.getRole().getAuthority(), user, store);
+
+        // 보낸 요청
+        String promptContent = String.format("제목: %s, 가격: %d. %s. 답변은 최대한 간결하게 50자 이내로 해줘", menu.getTitle(), menu.getPrice(), requestDto.getDetails());
+
+        // 요청보내고 답변 저장
+        String description = geminiApiClient.createDescription(menu.getTitle(), menu.getPrice(), requestDto.getDetails());
+
+        // 답변(메뉴 설명)  메뉴에 저장
+        menu.setDescription(description);
+        menuRepository.save(menu);
+
+        Prompt prompt = Prompt.builder()
+                .promptContent(promptContent)
+                .answer(description)
+                .storeMenu(menu)
+                .build();
+
+        promptRepository.save(prompt);
+
+        return PromptDto.ResponseDto.builder()
+                .menuId(menu.getId())
+                .description(menu.getDescription())
+                .build();
+    }
+
+    // 메뉴 생성 시 메뉴에 대한 설명을 직접 입력 하지 않았을 경우
+    @Transactional
+    public String createDescription(String title, long price, String details) {
+        String promptContent = String.format("제목: %s, 가격: %d. %s. 답변은 최대한 간결하게 50자 이내로 해줘", title, price, details);
+
+        String description = geminiApiClient.createDescription(title, price, details);
+
+        Prompt prompt = Prompt.builder()
+                .promptContent(promptContent)
+                .answer(description)
+                .build();
+
+        promptRepository.save(prompt);
+
+        return description;
+    }
+
+    private StoreMenu getMenu(UUID menuId) {
+        return menuRepository.findById(menuId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+    }
+    private Store getStore(UUID storeId) {
+        return storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+    }
+
+    private void checkUserIsStoreOwner(User user, Store store) {
+        if (!store.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+    }
+
+    // 손님이 아니며, 가게주인인지 검증이 필요한 경우
+    private void checkUserRole(String userRole, User user, Store store) {
+        if (userRole.equals(GlobalConst.ROLE_OWNER)) {
+            checkUserIsStoreOwner(user, store);
+        }
+        else if (!(userRole.equals(GlobalConst.ROLE_MANAGER) || userRole.equals(GlobalConst.ROLE_ADMIN))) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+    }
+
+
+
+}

--- a/src/main/java/com/spartaordersystem/domains/category/service/StoreCategoryService.java
+++ b/src/main/java/com/spartaordersystem/domains/category/service/StoreCategoryService.java
@@ -30,6 +30,10 @@ public class StoreCategoryService {
         Category category = checkCategoryExists(categoryName);
 
         store.setCategory(category);
+        /**
+         * 이게 있기 때문에 스토어서비스에 속하는게 맞다
+         * 동일하게 위치시키거나 로직을 합치거나
+         */
         storeRepository.save(store);
     }
 

--- a/src/main/java/com/spartaordersystem/domains/store/controller/StoreController.java
+++ b/src/main/java/com/spartaordersystem/domains/store/controller/StoreController.java
@@ -37,6 +37,9 @@ public class StoreController {
             @RequestBody CreateStoreDto.RequestDto requestDto
     ) {
         CreateStoreDto.ResponseDto responseDto = storeService.createStore(user, requestDto);
+        /**
+         * 컨트롤러는 비즈니스 로직 흐름이 있어선 안된다
+         */
 
         storeCategoryService.createStoreCategory(responseDto.getId(), user, requestDto.getCategoryName());
         responseDto.setCategoryName(requestDto.getCategoryName());

--- a/src/main/java/com/spartaordersystem/domains/storeMenu/entity/StoreMenu.java
+++ b/src/main/java/com/spartaordersystem/domains/storeMenu/entity/StoreMenu.java
@@ -1,5 +1,6 @@
 package com.spartaordersystem.domains.storeMenu.entity;
 
+import com.spartaordersystem.domains.ai.entity.Prompt;
 import com.spartaordersystem.domains.storeMenu.controller.dto.UpdateMenuDto;
 import com.spartaordersystem.domains.storeMenu.enums.MenuStatus;
 import com.spartaordersystem.domains.store.entity.Store;
@@ -14,6 +15,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -67,13 +69,17 @@ public class StoreMenu extends BaseAudit {
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
+    @OneToOne(mappedBy = "storeMenu", fetch = FetchType.LAZY)
+    private Prompt prompt;
+
     @Builder
-    public StoreMenu(String title, String description, long price, MenuStatus menuStatus, Store store) {
+    public StoreMenu(String title, String description, long price, MenuStatus menuStatus, Store store, Prompt prompt) {
         this.title = title;
         this.description = description;
         this.price = price;
         this.menuStatus = menuStatus;
         this.store = store;
+        this.prompt = prompt;
     }
 
     @Transactional
@@ -91,6 +97,10 @@ public class StoreMenu extends BaseAudit {
 
     public void setMenuStatus(MenuStatus menuStatus) {
         this.menuStatus = menuStatus;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
 }


### PR DESCRIPTION
#39 

#40 

기존에 있는 메뉴에 설명을 생성하는 것과
메뉴를 생성하며 가게주인이 설명을 입력하지않아 ai에 생성을 요청하는 것을 분리


요청을 보내며 JSON 포맷으로 변경하고
인가필터를 통과하도록 설정
그리고 POST 요청을 전송

요청을 보낸 후 답변을 저장하고 메뉴 설명을 변경 


**GEMINI_API_KEY 라는 환경변수가 등록되었습니다.  테스트 시 API키를 받아  환경변수 등록 후 테스트해주세요**