### PR TITLE
[feat] AI 요청 기록 조회

### DIFF
--- a/src/main/java/com/spartaordersystem/domains/ai/controller/PromptController.java
+++ b/src/main/java/com/spartaordersystem/domains/ai/controller/PromptController.java
@@ -42,5 +42,14 @@ public class PromptController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_MANAGER')")
+    @GetMapping
+    public ResponseEntity<BaseResponse> getPromptHistory(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<GetPromptDto.ResponseDto> responseDtoList = promptService.getPromptHistory(page, size);
+        BaseResponse response = BaseResponse.toSuccessResponse("프롬프트 기록 조회", responseDtoList);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/spartaordersystem/domains/ai/controller/dto/GetPromptDto.java
+++ b/src/main/java/com/spartaordersystem/domains/ai/controller/dto/GetPromptDto.java
@@ -1,0 +1,22 @@
+package com.spartaordersystem.domains.ai.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+public class GetPromptDto {
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class ResponseDto {
+        private UUID id;
+        private String promptContent;
+        private String answer;
+        private ZonedDateTime createdAt;
+    }
+}

--- a/src/main/java/com/spartaordersystem/global/exception/ErrorCode.java
+++ b/src/main/java/com/spartaordersystem/global/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     /*  400 BAD_REQUEST : 잘못된 요청  */
     ILLEGAL_ARGUMENT_ERROR(400, "잘못된 파라미터 전달"),
     CATEGORY_IS_DELETED(400, "이미 삭제된 카테고리입니다."),
+    INVALID_PAGE_OR_SIZE(400,  "유효하지 않은 페이지입니다."),
 
     /*  401 UNAUTHORIZED : 인증 안됨  */
     UNAUTHORIZED(401, "인증되지 않았습니다."),


### PR DESCRIPTION
## 요약

#41 

프롬프트에 질문과 답변을 저장
관리자 권한을 가진 경우 저장된 질문과 답변을 조회할 수 있도록 함
해당 메서드는 저장된 질문과 답변을 페이지네이션하여 조회
10 30 50 인 경우엔 해당 사이즈로,  그외의 경우엔 10으로 사이즈를 정하여 페이지네이션

요청기록은 페이지네이션을 하되  수정기능이 없어 생성일밖에 존재하지 않으므로  생성일 기준 내림차순으로 조회